### PR TITLE
Fix for storing dataframes with no data and only columns

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -408,3 +408,25 @@ def test_setitem_modification(entry_point):
     loaded = load_node(node.pk)
     assert loaded is not node
     assert_frame_equal(loaded.df, df_changed)
+
+
+@pytest.mark.parametrize(
+    "entry_point",
+    ("dataframe.frame",),
+)
+def test_empty_dataframe(entry_point):
+    """
+    Test that storing an empty dataframe works
+    """
+
+    PandasFrameData = DataFactory(entry_point)
+
+    # Example from pandas Docs
+    df = pd.DataFrame([], columns=["A", "B"])
+
+    node = PandasFrameData(df)
+    node.store()
+
+    loaded = load_node(node.pk)
+    assert loaded is not node
+    assert_frame_equal(loaded.df, df)


### PR DESCRIPTION
Fixes #2 

The pytables library does not store anything for empty dataframe and read_hdf excepts in this case. To fix this we check beforehand if the HDF5 file is empty and in this case create the dataframe from the columns attribute