### PR TITLE
🔧 MAINT: Add errors for pandas 2.X for dataframes containing timestamps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,19 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         aiida-version: ["stable"]
+        pandas-version: ["1.5", "stable"]
         include:
             - python-version: "3.8"
               aiida-version: "1.6.9"
+              pandas-version: "1.5"
+              allowed-to-fail: false
+            - python-version: "3.12"
+              aiida-version: "latest"
+              pandas-version: "stable"
+              allowed-to-fail: false
+            - python-version: "3.13"
+              aiida-version: "latest"
+              pandas-version: "stable"
               allowed-to-fail: false
       fail-fast: False
 
@@ -48,6 +58,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[testing]
+        pip install ${{ matrix.aiida-version }} ${{ matrix.pandas-version }}
         reentry scan || true
 
     - name: Run test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[docs]
+        pip install pandas>2
     - name: Build docs
       run: cd docs && make
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,20 +10,20 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        aiida-version: [">=2.6"]
-        pandas-version: ["1.5", ">=2.3"]
+        aiida-version: ["aiida-core>=2.6"]
+        pandas-version: ["pandas==1.5", "pandas>=2.3"]
         include:
             - python-version: "3.8"
-              aiida-version: "1.6.9"
-              pandas-version: "1.5"
+              aiida-version: "aiida-core==1.6.9"
+              pandas-version: "pandas==1.5"
               allowed-to-fail: false
             - python-version: "3.12"
-              aiida-version: "latest"
-              pandas-version: "stable"
+              aiida-version: "aiida-core>=2.6"
+              pandas-version: "pandas>=2.3"
               allowed-to-fail: false
             - python-version: "3.13"
-              aiida-version: "latest"
-              pandas-version: "stable"
+              aiida-version: "aiida-core>=2.6"
+              pandas-version: "pandas>=2.3"
               allowed-to-fail: false
       fail-fast: False
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,17 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         aiida-version: ["aiida-core>=2.6"]
         pandas-version: ["pandas==1.5", "pandas>=2.3"]
         include:
             - python-version: "3.8"
               aiida-version: "aiida-core==1.6.9"
               pandas-version: "pandas==1.3"
+              allowed-to-fail: false
+            - python-version: "3.8"
+              aiida-version: "aiida-core>=2.6"
+              pandas-version: "pandas==1.5"
               allowed-to-fail: false
             - python-version: "3.12"
               aiida-version: "aiida-core>=2.6"
@@ -86,7 +90,6 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[docs]
-        pip install pandas>2
     - name: Build docs
       run: cd docs && make
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,10 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: "3.12"
+        python-version: "3.11"
     - name: Install python dependencies
       run: |
         pip install --upgrade pip
@@ -83,10 +83,10 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.12
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: "3.12"
+        python-version: "3.11"
     - name: Install python dependencies
       run: |
         pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         include:
             - python-version: "3.8"
               aiida-version: "aiida-core==1.6.9"
-              pandas-version: "pandas==1.5"
+              pandas-version: "pandas==1.3"
               allowed-to-fail: false
             - python-version: "3.12"
               aiida-version: "aiida-core>=2.6"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        aiida-version: ["stable", "1.6.9"]
+        aiida-version: ["stable"]
+        include:
+            - python-version: "3.8"
+              aiida-version: "1.6.9"
+              allowed-to-fail: false
       fail-fast: False
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.7","3.8", "3.9", "3.10", "3.11"] #3.7 will install AiiDA 1.X
-        aiida-version: ["stable"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        aiida-version: ["stable", "1.6.9"]
       fail-fast: False
 
     services:
@@ -63,10 +63,10 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.12"
     - name: Install python dependencies
       run: |
         pip install --upgrade pip
@@ -79,10 +79,10 @@ jobs:
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.8
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.12"
     - name: Install python dependencies
       run: |
         pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        aiida-version: ["latest"]
-        pandas-version: ["1.5", "latest"]
+        aiida-version: [">=2.6"]
+        pandas-version: ["1.5", ">=2.3"]
         include:
             - python-version: "3.8"
               aiida-version: "1.6.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        aiida-version: ["stable"]
-        pandas-version: ["1.5", "stable"]
+        aiida-version: ["latest"]
+        pandas-version: ["1.5", "latest"]
         include:
             - python-version: "3.8"
               aiida-version: "1.6.9"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         aiida-version: ["stable"]
         include:
             - python-version: "3.8"

--- a/aiida_dataframe/data/dataframe.py
+++ b/aiida_dataframe/data/dataframe.py
@@ -66,7 +66,7 @@ class PandasFrameData(SinglefileData):
             #See https://github.com/pandas-dev/pandas/issues/59004
 
             dtypes = df.dtypes.values
-            if any(dtype.startswith("datetime64") and dtype != "datetime64[ns]"):
+            if any(dtype.startswith("datetime64") and dtype != "datetime64[ns]" for dtype in dtypes):
                 raise ValueError("Timestamp entries in a dataframe are not correctly handled in HDF5 IO for pandas 2.X.\n"
                                  "Either convert to datetime64[ns] manually before storing or remove the entry. This issue will be fixed in pandas 3.0\n"
                                  "For more information see https://github.com/pandas-dev/pandas/issues/59004")

--- a/aiida_dataframe/data/dataframe.py
+++ b/aiida_dataframe/data/dataframe.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import shutil
 import tempfile
 from typing import Any
-from packaging.version import Version
 
+from packaging.version import Version
 import pandas as pd
 from pandas.util import hash_pandas_object
 
@@ -60,17 +60,24 @@ class PandasFrameData(SinglefileData):
             except AttributeError:
                 filename = self.DEFAULT_FILENAME
 
-        if Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"):
-            #Bug in pandas HDF5 IO concerning timestamps the data type is not correctly roundtripped
-            #This is fixed in pandas 3.0 (once it's released)
-            #See https://github.com/pandas-dev/pandas/issues/59004
+        if Version(pd.__version__) >= Version("2.0.0") and Version(
+            pd.__version__
+        ) < Version("3.0.0"):
+            # Bug in pandas HDF5 IO concerning timestamps the data type is not correctly roundtripped
+            # This is fixed in pandas 3.0 (once it's released)
+            # See https://github.com/pandas-dev/pandas/issues/59004
 
             dtypes = df.dtypes.astype("string").values
-            if any(dtype.startswith("datetime64") and dtype != "datetime64[ns]" for dtype in dtypes):
-                raise ValueError("Timestamp entries in a dataframe are not correctly handled in HDF5 IO for pandas 2.X.\n"
-                                 "Either convert to datetime64[ns] manually before storing or remove the entry. This issue will be fixed in pandas 3.0\n"
-                                 "For more information see https://github.com/pandas-dev/pandas/issues/59004")
-        
+            if any(
+                dtype.startswith("datetime64") and dtype != "datetime64[ns]"
+                for dtype in dtypes
+            ):
+                raise ValueError(
+                    "Timestamp entries in a dataframe are not correctly handled in HDF5 IO for pandas 2.X.\n"
+                    "Either convert to datetime64[ns] manually before storing or remove the entry. This issue will be fixed in pandas 3.0\n"
+                    "For more information see https://github.com/pandas-dev/pandas/issues/59004"
+                )
+
         with tempfile.TemporaryDirectory() as td:
             df.to_hdf(Path(td) / self.DEFAULT_FILENAME, "w", format="table")
 

--- a/aiida_dataframe/data/dataframe.py
+++ b/aiida_dataframe/data/dataframe.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import shutil
 import tempfile
 from typing import Any
+from packaging.version import Version
 
 import pandas as pd
 from pandas.util import hash_pandas_object
@@ -59,6 +60,17 @@ class PandasFrameData(SinglefileData):
             except AttributeError:
                 filename = self.DEFAULT_FILENAME
 
+        if Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"):
+            #Bug in pandas HDF5 IO concerning timestamps the data type is not correctly roundtripped
+            #This is fixed in pandas 3.0 (once it's released)
+            #See https://github.com/pandas-dev/pandas/issues/59004
+
+            dtypes = df.dtypes.values
+            if any(dtype.startswith("datetime64") and dtype != "datetime64[ns]"):
+                raise ValueError("Timestamp entries in a dataframe are not correctly handled in HDF5 IO for pandas 2.X.\n"
+                                 "Either convert to datetime64[ns] manually before storing or remove the entry. This issue will be fixed in pandas 3.0\n"
+                                 "For more information see https://github.com/pandas-dev/pandas/issues/59004")
+        
         with tempfile.TemporaryDirectory() as td:
             df.to_hdf(Path(td) / self.DEFAULT_FILENAME, "w", format="table")
 

--- a/aiida_dataframe/data/dataframe.py
+++ b/aiida_dataframe/data/dataframe.py
@@ -65,7 +65,7 @@ class PandasFrameData(SinglefileData):
             #This is fixed in pandas 3.0 (once it's released)
             #See https://github.com/pandas-dev/pandas/issues/59004
 
-            dtypes = df.dtypes.values
+            dtypes = df.dtypes.astype("string").values
             if any(dtype.startswith("datetime64") and dtype != "datetime64[ns]" for dtype in dtypes):
                 raise ValueError("Timestamp entries in a dataframe are not correctly handled in HDF5 IO for pandas 2.X.\n"
                                  "Either convert to datetime64[ns] manually before storing or remove the entry. This issue will be fixed in pandas 3.0\n"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "aiida": ("https://aiida.readthedocs.io/projects/aiida-core/en/latest", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/1.5", None),
+    "pandas": ("http://pandas.pydata.org/pandas-docs/dev", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "aiida": ("https://aiida.readthedocs.io/projects/aiida-core/en/latest", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/dev", None),
+    "pandas": ("http://pandas.pydata.org/pandas-docs/1.5", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,14 +14,7 @@ import os
 import sys
 import time
 
-from aiida.manage.configuration import load_documentation_profile
-
 import aiida_dataframe
-
-# -- AiiDA-related setup --------------------------------------------------
-
-# Load the dummy documentation profile
-load_documentation_profile()
 
 # -- General configuration ------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keywords = ["aiida", "plugin"]
 requires-python = ">=3.7"
 dependencies = [
     "aiida-core>=1.0,<3",
-    "pandas",
+    "pandas~=1.0",
     "tables",
     "tabulate"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "Natural Language :: English",
     'Development Status :: 4 - Beta',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
@@ -29,7 +28,7 @@ keywords = ["aiida", "plugin"]
 requires-python = ">=3.7"
 dependencies = [
     "aiida-core>=1.0,<3",
-    "pandas~=1.0",
+    "pandas",
     "tables",
     "tabulate"
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """ Tests for command line interface."""
 import pytest
 from click.testing import CliRunner
+from packaging.version import Version
 import numpy as np
 import pandas as pd
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 """ Tests for command line interface."""
+import pytest
 from click.testing import CliRunner
 import numpy as np
 import pandas as pd

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,18 +1,21 @@
 """ Tests for command line interface."""
-import pytest
 from click.testing import CliRunner
-from packaging.version import Version
 import numpy as np
+from packaging.version import Version
 import pandas as pd
+import pytest
 
 from aiida.plugins import DataFactory
 
 from aiida_dataframe.cli import export, list_, show
 
 pandas_2_xfail = pytest.mark.xfail(
-    Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"), reason="Pandas 2 does not handle datetime64[s] with HDF5 correctly. Correct failure behaviour tested in test_roundtrip", 
-    raises=ValueError
+    Version(pd.__version__) >= Version("2.0.0")
+    and Version(pd.__version__) < Version("3.0.0"),
+    reason="Pandas 2 does not handle datetime64[s] with HDF5 correctly. Correct failure behaviour tested in test_roundtrip",
+    raises=ValueError,
 )
+
 
 # pylint: disable=attribute-defined-outside-init
 class TestDataCli:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,10 @@ from aiida.plugins import DataFactory
 
 from aiida_dataframe.cli import export, list_, show
 
+pandas_2_xfail = pytest.mark.xfail(
+    Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"), reason="Pandas 2 does not handle datetime64[s] with HDF5 correctly. Correct failure behaviour tested in test_roundtrip", 
+    raises=ValueError
+)
 
 # pylint: disable=attribute-defined-outside-init
 class TestDataCli:
@@ -37,6 +41,7 @@ class TestDataCli:
         result = self.runner.invoke(list_, catch_exceptions=False)
         assert str(self.df_node.pk) in result.output
 
+    @pandas_2_xfail
     def test_dataframe_export(self, file_regression):
         """Test 'verdi dataframe export'
         Tests that it can be reached and that it shows the contents of the node
@@ -47,6 +52,7 @@ class TestDataCli:
         )
         file_regression.check(result.output.strip("\n"), extension=".csv")
 
+    @pandas_2_xfail
     def test_dataframe_show(self, file_regression):
         """Test 'verdi dataframe show'
         Tests that it can be reached and that it shows the contents of the node

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ class TestDataCli:
         self.df_node.store()
         self.runner = CliRunner()
 
+    @pandas_2_xfail
     def test_dataframe_list(self):
         """Test 'verdi data dataframe list'
         Tests that it can be reached and that it lists the node we have set up.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -75,7 +75,7 @@ def test_multiindex_columns_roundtrip(entry_point):
     if Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"):
         with pytest.raises(ValueError) as excinfo:
             node = PandasFrameData(df)
-            assert "datetime64" in excinfo.value
+        assert "datetime64" in excinfo.value
     else:
         node = PandasFrameData(df)
         node.store()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,19 +1,20 @@
 """ Tests for Data plugin."""
 
 import numpy as np
+from packaging.version import Version
 import pandas as pd
 from pandas.testing import assert_frame_equal
 import pytest
-from packaging.version import Version
 
 from aiida.common import exceptions
 from aiida.orm import QueryBuilder, load_node
 from aiida.plugins import DataFactory
 
-
 pandas_2_xfail = pytest.mark.xfail(
-    Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"), reason="Pandas 2 does not handle datetime64[s] with HDF5 correctly. Correct failure behaviour tested in test_roundtrip", 
-    raises=ValueError
+    Version(pd.__version__) >= Version("2.0.0")
+    and Version(pd.__version__) < Version("3.0.0"),
+    reason="Pandas 2 does not handle datetime64[s] with HDF5 correctly. Correct failure behaviour tested in test_roundtrip",
+    raises=ValueError,
 )
 
 
@@ -40,7 +41,9 @@ def test_roundtrip(entry_point):
     )
 
     PandasFrameData = DataFactory(entry_point)
-    if Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"):
+    if Version(pd.__version__) >= Version("2.0.0") and Version(
+        pd.__version__
+    ) < Version("3.0.0"):
         with pytest.raises(ValueError) as excinfo:
             node = PandasFrameData(df)
         assert "datetime64" in str(excinfo.value)
@@ -48,7 +51,7 @@ def test_roundtrip(entry_point):
         node = PandasFrameData(df)
         node.store()
         assert node.is_stored
-    
+
         loaded = load_node(node.pk)
         assert loaded is not node
         assert_frame_equal(loaded.df, df)
@@ -105,6 +108,7 @@ def test_multiindex_index_roundtrip(entry_point):
     loaded = load_node(node.pk)
     assert loaded is not node
     assert_frame_equal(loaded.df, df)
+
 
 @pandas_2_xfail
 @pytest.mark.parametrize(
@@ -204,6 +208,7 @@ def test_query_multiindex_columns(entry_point):
     assert len(query.all()) == 1
     assert query.one()[0].uuid == df_node_1.uuid
 
+
 @pandas_2_xfail
 @pytest.mark.parametrize(
     "entry_point",
@@ -247,6 +252,7 @@ def test_query_index(entry_point):
 
     assert len(query.all()) == 1
     assert query.one()[0].uuid == df_node_1.uuid
+
 
 @pandas_2_xfail
 @pytest.mark.parametrize("entry_point", ("dataframe.frame",))
@@ -325,6 +331,7 @@ def test_wrong_inputs(entry_point):
     with pytest.raises(TypeError):
         PandasFrameData([1, 2, 3])
 
+
 @pandas_2_xfail
 @pytest.mark.parametrize(
     "entry_point",
@@ -354,6 +361,7 @@ def test_modification_after_store(entry_point):
 
     with pytest.raises(exceptions.ModificationNotAllowed):
         node.df = node.df.rename({"A": "A_rename"})
+
 
 @pandas_2_xfail
 @pytest.mark.parametrize(
@@ -386,6 +394,7 @@ def test_modification_before_store(entry_point):
     loaded = load_node(node.pk)
     assert loaded is not node
     assert_frame_equal(loaded.df, df.rename({"A": "A_rename"}))
+
 
 @pandas_2_xfail
 @pytest.mark.parametrize(
@@ -443,6 +452,7 @@ def test_empty_dataframe(entry_point):
     assert loaded is not node
     assert_frame_equal(loaded.df, df)
 
+
 @pandas_2_xfail
 @pytest.mark.parametrize(
     "entry_point",
@@ -472,6 +482,7 @@ def test_modification_before_instance_update(entry_point):
     node = PandasFrameData(df)
     node.df = node.df.set_index("C")
     assert_frame_equal(node.df, df_changed)
+
 
 @pandas_2_xfail
 @pytest.mark.parametrize(
@@ -506,6 +517,7 @@ def test_non_default_filename(entry_point):
     assert loaded is not node
     assert loaded.list_object_names() == ["non_default.h5"]
     assert_frame_equal(loaded.df, df)
+
 
 @pandas_2_xfail
 @pytest.mark.parametrize(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -43,7 +43,7 @@ def test_roundtrip(entry_point):
     if Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"):
         with pytest.raises(ValueError) as excinfo:
             node = PandasFrameData(df)
-        assert "datetime64" in excinfo.value
+        assert "datetime64" in str(excinfo.value)
     else:
         node = PandasFrameData(df)
         node.store()
@@ -204,7 +204,7 @@ def test_query_multiindex_columns(entry_point):
     assert len(query.all()) == 1
     assert query.one()[0].uuid == df_node_1.uuid
 
-
+@pandas_2_xfail
 @pytest.mark.parametrize(
     "entry_point",
     ("dataframe.frame",),

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -11,8 +11,9 @@ from aiida.orm import QueryBuilder, load_node
 from aiida.plugins import DataFactory
 
 
-pandas_2_xfail = pytest.mark.skipif(
-    Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"), reason="Pandas 2 does not handle datetime64[s] with HDF5 correctly. Correct failure behaviour tested in test_roundtrip"
+pandas_2_xfail = pytest.mark.xfail(
+    Version(pd.__version__) >= Version("2.0.0") and Version(pd.__version__) < Version("3.0.0"), reason="Pandas 2 does not handle datetime64[s] with HDF5 correctly. Correct failure behaviour tested in test_roundtrip", 
+    raises=ValueError
 )
 
 


### PR DESCRIPTION
pandas 2.X does not correctly handle `pd.Timestamp` in roundtrips to hdf5 files. The returned datatype is a datetime64[ns] instead of the expected datetime64[s]. Since everything else works with pandas 2 though, only a error message for dataframes created with these datatypes is added and the version requirements are not changed. In pandas 3.0 this issue seems to be already fixed.

Additionally some changes/updates to the CI are included (python versions, testing different pandas versions, etc.)