### PR TITLE
🔧 MAINT: Fixes to documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,10 +38,8 @@ extensions = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "aiida": ("https://aiida.readthedocs.io/projects/aiida-core/en/latest", None),
-    "pandas": ("http://pandas.pydata.org/pandas-docs/dev", None),
+    "pandas": ("http://pandas.pydata.org/pandas-docs/stable", None),
 }
-
-autodoc_type_aliases = {'pandas.core.frame.DataFrame': 'pandas.DataFrame'}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     "sphinxcontrib.contentui",
+    "sphinx_autodoc_typehints",
     "aiida.sphinxext",
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,6 +41,8 @@ intersphinx_mapping = {
     "pandas": ("http://pandas.pydata.org/pandas-docs/dev", None),
 }
 
+autodoc_type_aliases = {'pandas.core.frame.DataFrame': 'pandas.DataFrame'}
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ docs = [
     "sphinx",
     "sphinxcontrib-contentui",
     "sphinxcontrib-details-directive",
+    "sphinx-autodoc-typehints"
     "furo",
     "markupsafe<2.1"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ docs = [
     "sphinx",
     "sphinxcontrib-contentui",
     "sphinxcontrib-details-directive",
-    "sphinx-autodoc-typehints"
+    "sphinx-autodoc-typehints",
     "furo",
     "markupsafe<2.1"
 ]


### PR DESCRIPTION
Fix to make docs build again. intersphinx for pandas was linked to the dev docs, which is on 3.0 and apparently moves the reference for the DataFrame.

Additionally added `sphinx-autodoc-typehints` to document function signatures.