### PR TITLE
🚀 Release ``0.2.0``

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
           flit publish
         env:
           FLIT_USERNAME: __token__
-          FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}
+          FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}
           FLIT_INDEX_URL: https://test.pypi.org/legacy/
 
       - name: Build and Publish to PyPi
@@ -46,4 +46,4 @@ jobs:
           flit publish
         env:
           FLIT_USERNAME: __token__
-          FLIT_PASSWORD: ${{ secrets.PYPI_KEY }}
+          FLIT_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_call]
 
 jobs:
 

--- a/aiida_dataframe/__init__.py
+++ b/aiida_dataframe/__init__.py
@@ -4,4 +4,4 @@ aiida_dataframe
 AiiDA data plugin for pandas DataFrame objects
 """
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"


### PR DESCRIPTION
Changes:

- Added errors when using the plugin with pandas versions between ``2.0`` and ``3.0`` with dataframes containing timestamps (roundtrip not possible due to a bug in pandas) [#18]